### PR TITLE
feat: 게시글 수정, 삭제 시 비밀번호 일치 확인

### DIFF
--- a/src/main/java/com/sparta/crud/controller/BoardController.java
+++ b/src/main/java/com/sparta/crud/controller/BoardController.java
@@ -7,41 +7,41 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Map;
 
 @RestController
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class BoardController {
 
     private final BoardService boardService;
 
     // 게시글 작성
-    @PostMapping("/api/board")
+    @PostMapping("/board")
     public BoardResponseDto createBorad(@RequestBody BoardRequestDto requestDto) {
         return boardService.createBoard(requestDto);
     }
 
     // 전체 게시글 조회
-    @GetMapping("/api/board")
+    @GetMapping("/board")
     public List<BoardResponseDto> getBoardList() {
         return boardService.getBoardList();
     }
 
     // 게시글 상세 조회
-    @GetMapping("/api/board/{id}")
+    @GetMapping("/board/{id}")
     public BoardResponseDto getBoard(@PathVariable Long id) {
         return boardService.getBoard(id);
     }
 
     // 게시글 수정
-    @PutMapping("/api/board/{id}")
+    @PutMapping("/board/{id}")
     public BoardResponseDto updateBoard(@PathVariable Long id, @RequestBody BoardRequestDto requestDto) {
         return boardService.update(id, requestDto);
     }
 
     // 게시글 삭제
-    @DeleteMapping("/api/board/{id}")
-    public Map<String, Object> deleteBoard(@PathVariable Long id) {
-        return boardService.deleteBoard(id);
+    @DeleteMapping("/board/{id}")
+    public BoardResponseDto deleteBoard(@PathVariable Long id, @RequestBody BoardRequestDto requestDto) {
+        return boardService.deleteBoard(id, requestDto);
     }
 }

--- a/src/main/java/com/sparta/crud/dto/BoardResponseDto.java
+++ b/src/main/java/com/sparta/crud/dto/BoardResponseDto.java
@@ -2,12 +2,9 @@ package com.sparta.crud.dto;
 
 import com.sparta.crud.entity.Board;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 import java.time.LocalDateTime;
 
 @Getter
-@NoArgsConstructor
 public class BoardResponseDto {
     private Long id;
     private String title;
@@ -15,14 +12,20 @@ public class BoardResponseDto {
     private String content;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
+    private Boolean success;
 
-    public BoardResponseDto(Board board) {
+    public BoardResponseDto(Board board, Boolean success) {
         this.id = board.getId();
         this.title = board.getTitle();
         this.name = board.getName();
         this.content = board.getContent();
         this.createdAt = board.getCreatedAt();
         this.modifiedAt = board.getModifiedAt();
+        this.success = success;
+    }
+
+    public BoardResponseDto(Boolean success) {
+        this.success = success;
     }
 
 }

--- a/src/main/java/com/sparta/crud/service/BoardService.java
+++ b/src/main/java/com/sparta/crud/service/BoardService.java
@@ -9,9 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -23,7 +21,7 @@ public class BoardService {
     public BoardResponseDto createBoard(BoardRequestDto requestDto) {
         Board board = new Board(requestDto);
         boardRepository.save(board);
-        return new BoardResponseDto(board);
+        return new BoardResponseDto(board, true);
     }
 
     @Transactional(readOnly = true)
@@ -31,7 +29,7 @@ public class BoardService {
         List<Board> boardList = boardRepository.findAllByOrderByCreatedAtDesc();
         List<BoardResponseDto> boardResponseDtoList = new ArrayList<>();
         for (Board board : boardList) {
-            boardResponseDtoList.add(new BoardResponseDto(board));
+            boardResponseDtoList.add(new BoardResponseDto(board, true));
         }
         return boardResponseDtoList;
     }
@@ -41,7 +39,7 @@ public class BoardService {
         Board board = boardRepository.findById(id).orElseThrow(
                 () -> new IllegalArgumentException("아이디가 존재하지 않습니다.")
         );
-        return new BoardResponseDto(board);
+        return new BoardResponseDto(board, true);
     }
 
 //    @Transactional
@@ -55,24 +53,39 @@ public class BoardService {
         Board savedBoard = boardRepository.save(board);
 
         // 여기서 비밀번호 일치하는지 확인
+        if (requestDto.getPw().equals(board.getPw())) {
+            // 비밀번호 일치
 
+            // board 객체를 입력 받은 값으로 변경
+            savedBoard.update(requestDto);
+            // board를 저장
+            Board resultBoard = boardRepository.save(savedBoard);
+            // ResponseDto로 반환
+            return new BoardResponseDto(resultBoard, true);
+        } else {
+            // 비밀번호 불일치
 
-        // board 객체를 입력 받은 값으로 변경
-        savedBoard.update(requestDto);
+            return new BoardResponseDto(false);
+        }
 
-        // board를 저장
-        Board resultBoard = boardRepository.save(savedBoard);
-
-        // ResponseDto로 반환
-        return new BoardResponseDto(resultBoard);
     }
 
     @Transactional
-    public Map<String, Object> deleteBoard(Long id) {
-        Map<String, Object> response = new HashMap<>();
-        boardRepository.deleteById(id);
-        response.put("success", true);
-        return response;
-    }
+    public BoardResponseDto deleteBoard(Long id, BoardRequestDto requestDto) {
+        Board board = boardRepository.findById(id).orElseThrow(
+                () -> new IllegalArgumentException("아이디가 존재하지 않습니다.")
+        );
+        if (requestDto.getPw().equals(board.getPw())) {
+            // 비밀번호 일치
 
+            // 게시글 삭제
+            boardRepository.deleteById(id);
+            // ResponseDto로 반환
+            return new BoardResponseDto(true);
+        } else {
+            // 비밀번호 불일치
+
+            return new BoardResponseDto(false);
+        }
+    }
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/3-> develop

### 변경 사항
- Service단에서 비밀번호 일치 로직 구현
- ResponseDto에 Boolean 타입의 success 필드 추가하여 Dto 상태값 함께 전송
- 게시글 삭제 시 기존 HashMap으로 처리되던 부분 ResponseDto로 변경

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
ResponseDto의 success 상태가 false 일 시 success 제외 전체 필드값이 null로 전달되어 추후 수정 예정입니다.