### PR TITLE
refactor: User Entity 연관관계 매핑

### DIFF
--- a/src/main/java/com/sparta/crud/entity/Board.java
+++ b/src/main/java/com/sparta/crud/entity/Board.java
@@ -17,6 +17,14 @@ public class Board extends Timestamped{
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
+    @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE)
+    @OrderBy("createdAt DESC")
+    private List<Comment> comments = new ArrayList<>();
+
+    @ManyToOne
+    @JoinColumn(name = "USER_ID", nullable = false)
+    private User user;
+
     @Column(nullable = false)
     private String title;
 
@@ -26,22 +34,15 @@ public class Board extends Timestamped{
     @Column(nullable = false)
     private String content;
 
-    @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE)
-    @OrderBy("createdAt DESC")
-    private List<Comment> comments = new ArrayList<>();
-
-    public Board(BoardRequestDto requestDto, String username) {
+    public Board(BoardRequestDto requestDto, User user) {
         this.title = requestDto.getTitle();
         this.content = requestDto.getContent();
-        this.username = username;
+        this.username = user.getUsername();
+        this.user = user;
     }
 
     public void update(BoardRequestDto requestDto) {
         this.title = requestDto.getTitle();
         this.content = requestDto.getContent();
-    }
-
-    public void addComments(Comment comment) {
-        this.comments.add(comment);
     }
 }

--- a/src/main/java/com/sparta/crud/entity/Comment.java
+++ b/src/main/java/com/sparta/crud/entity/Comment.java
@@ -15,20 +15,25 @@ public class Comment extends Timestamped{
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
+    @ManyToOne
+    @JoinColumn(name = "BOARD_ID", nullable = false)
+    private Board board;
+
+    @ManyToOne
+    @JoinColumn(name = "USER_ID", nullable = false)
+    private User user;
+
     @Column(nullable = false)
     private String username;
 
     @Column(nullable = false)
     private String comment;
 
-    @ManyToOne
-    @JoinColumn(name = "BOARD_ID", nullable = false)
-    private Board board;
-
-    public Comment(CommentRequestDto commentRequestDto, String username, Board board) {
+    public Comment(CommentRequestDto commentRequestDto, Board board, User user) {
         this.comment = commentRequestDto.getComment();
-        this.username = username;
+        this.username = user.getUsername();
         this.board = board;
+        this.user = user;
     }
 
     public void update(CommentRequestDto commentRequestDto) {

--- a/src/main/java/com/sparta/crud/entity/User.java
+++ b/src/main/java/com/sparta/crud/entity/User.java
@@ -4,6 +4,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity(name = "users")
 @Getter
@@ -12,6 +14,12 @@ public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
+
+    @OneToMany(mappedBy = "user")
+    private List<Board> boardList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<Comment> commentList = new ArrayList<>();
 
     // nullable: null 허용 여부
     // unique: 중복 허용 여부 (false 일때 중복 허용)

--- a/src/main/java/com/sparta/crud/repository/BoardRepository.java
+++ b/src/main/java/com/sparta/crud/repository/BoardRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
     List<Board> findAllByOrderByCreatedAtDesc();
-    Optional<Board> findByIdAndUsername(Long id, String username);
+    Optional<Board> findByIdAndUserId(Long id, Long UserId);
 }

--- a/src/main/java/com/sparta/crud/repository/CommentRepository.java
+++ b/src/main/java/com/sparta/crud/repository/CommentRepository.java
@@ -1,14 +1,10 @@
 package com.sparta.crud.repository;
 
-import com.sparta.crud.entity.Board;
 import com.sparta.crud.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    List<Comment> findAllByBoardIdOrderByCreatedAtDesc(Board board);
-
-    Optional<Comment> findByIdAndUsername(Long cmtId, String username);
+    Optional<Comment> findByIdAndUserId(Long cmtId, Long UserId);
 }

--- a/src/main/java/com/sparta/crud/service/BoardService.java
+++ b/src/main/java/com/sparta/crud/service/BoardService.java
@@ -49,7 +49,7 @@ public class BoardService {
             );
 
             // 요청 받은 DTO로 DB에 저장할 객체 만들기
-            Board board = boardRepository.saveAndFlush(new Board(requestDto, user.getUsername()));
+            Board board = boardRepository.saveAndFlush(new Board(requestDto, user));
 
             return new BoardOneResponseDto(StatusEnum.OK, board);
 
@@ -122,8 +122,8 @@ public class BoardService {
                 );
 
             } else {
-                // 입력 받은 게시글 id, 토큰에서 가져온 username과 일치하는 DB 조회
-                board = boardRepository.findByIdAndUsername(id, user.getUsername()).orElseThrow(
+                // 입력 받은 게시글 id, 토큰에서 가져온 userId와 일치하는 DB 조회
+                board = boardRepository.findByIdAndUserId(id, user.getId()).orElseThrow(
                         () -> new CutomException(AUTHORIZATION)
                 );
             }
@@ -175,8 +175,8 @@ public class BoardService {
                 );
 
             } else {
-                // 입력 받은 게시글 id, 토큰에서 가져온 username과 일치하는 DB 조회
-                board = boardRepository.findByIdAndUsername(id, user.getUsername()).orElseThrow(
+                // 입력 받은 게시글 id, 토큰에서 가져온 userId와 일치하는 DB 조회
+                board = boardRepository.findByIdAndUserId(id, user.getId()).orElseThrow(
                         () -> new CutomException(AUTHORIZATION)
                 );
             }

--- a/src/main/java/com/sparta/crud/service/CommentService.java
+++ b/src/main/java/com/sparta/crud/service/CommentService.java
@@ -12,7 +12,6 @@ import com.sparta.crud.repository.UserRepository;
 import com.sparta.crud.util.exception.CutomException;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,7 +54,7 @@ public class CommentService {
             );
 
             // 요청 받은 DTO로 DB에 저장할 객체 만들기
-            Comment comment = commentRepository.save(new Comment(commentRequestDto, user.getUsername(), board));
+            Comment comment = commentRepository.save(new Comment(commentRequestDto, board, user));
 
             return new CommentOneResponseDto(StatusEnum.OK, comment);
 
@@ -100,8 +99,8 @@ public class CommentService {
                         () -> new CutomException(NOT_FOUND_COMMENT)
                 );
             } else {
-                // 입력 받은 댓글 id, 토큰에서 가져온 username과 일치하는 DB 조회
-                comment = commentRepository.findByIdAndUsername(cmtId, user.getUsername()).orElseThrow(
+                // 입력 받은 댓글 id, 토큰에서 가져온 userId와 일치하는 DB 조회
+                comment = commentRepository.findByIdAndUserId(cmtId, user.getId()).orElseThrow(
                         () -> new CutomException(AUTHORIZATION)
                 );
             }
@@ -152,8 +151,8 @@ public class CommentService {
                         () -> new CutomException(NOT_FOUND_COMMENT)
                 );
             } else {
-                // 입력 받은 댓글 id, 토큰에서 가져온 username과 일치하는 DB 조회
-                comment = commentRepository.findByIdAndUsername(cmtId, user.getUsername()).orElseThrow(
+                // 입력 받은 댓글 id, 토큰에서 가져온 userId와 일치하는 DB 조회
+                comment = commentRepository.findByIdAndUserId(cmtId, user.getId()).orElseThrow(
                         () -> new CutomException(AUTHORIZATION)
                 );
             }


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링

### 반영 브랜치
feature/19-> 2week

### 변경 사항
- 기존 username만 따로 가져가던 형태에서 관계를 매핑하여 User 객체를 통째로 참조하도록 변경
- 게시글, 댓글 모두 수정/삭제 시 username과 일치하는게 아닌 userId와 일치하는 값을 조회

### 테스트 결과
Postman 테스트 결과 이상 없습니다.